### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vue 2 + Typescript + Vite
 
-This template should help get you started developing with Vue 3 and Typescript in Vite.
+This template should help get you started developing with Vue 2 and Typescript in Vite.
 
 ## Recommended IDE Setup
 


### PR DESCRIPTION
Fix typo in readme, instead -> `vue 2` instead of `vue 3`